### PR TITLE
Cleanup subscription maps on unsubscribe

### DIFF
--- a/test/nats_SUITE.erl
+++ b/test/nats_SUITE.erl
@@ -11,6 +11,7 @@ all() ->
      connect_verbose_ok,
      connect_verbose_fail,
      connect_fail_reconnect_infinity,
+     disconnect_ok,
      pub_ok,
      pub_verbose_ok,
      pub_with_buffer_size,
@@ -106,6 +107,14 @@ connect_fail_reconnect_infinity(_) ->
         ok
     end,
     false = nats:is_ready(C).
+
+disconnect_ok(_) ->
+    Host = <<"127.0.0.1">>,
+    Port = 4222,
+    {ok, C} = nats:connect(Host, Port, #{verbose => true}),
+    ok = nats:disconnect(C),
+    {error, not_found} = nats:is_ready(C).
+
 
     pub_ok(_) ->
         {ok, C} = nats:connect(<<"127.0.0.1">>, 4222),


### PR DESCRIPTION
Hi again,

Added some clean-up of the subscription maps to avoid them to grow for ever.
I had problem how to handle if max_messages was used in unsub, but we do not
use that so I appreciate if this also could be merged. Maybe you have ideas for max_messages?

Also added a disconnect test for my earlier commit.